### PR TITLE
fix matrix4x4 mul order bug

### DIFF
--- a/Chapter3/src/DXMath/Matrix4.h
+++ b/Chapter3/src/DXMath/Matrix4.h
@@ -80,7 +80,7 @@ namespace Math
 
 		INLINE Vector4 XM_CALLCONV  operator* (const Vector3& vec) const { return Vector4(XMVector3Transform(vec, m_mat)); }
 		INLINE Vector4  XM_CALLCONV operator* (const Vector4& vec) const { return Vector4(XMVector4Transform(vec, m_mat)); }
-		INLINE Matrix4  XM_CALLCONV operator* (const Matrix4& mat) const { return Matrix4(XMMatrixMultiply(mat, m_mat)); }
+		INLINE Matrix4  XM_CALLCONV operator* (const Matrix4& mat) const { return Matrix4(XMMatrixMultiply(m_mat,mat )); }
 
 		static INLINE Matrix4 XM_CALLCONV  MakeScale(float scale) { return Matrix4(XMMatrixScaling(scale, scale, scale)); }
 		static INLINE Matrix4 XM_CALLCONV  MakeScale(const Vector3& scale) { return Matrix4(XMMatrixScalingFromVector(scale)); }

--- a/Chapter4/src/DXMath/Matrix4.h
+++ b/Chapter4/src/DXMath/Matrix4.h
@@ -80,7 +80,7 @@ namespace Math
 
 		INLINE Vector4 XM_CALLCONV  operator* (const Vector3& vec) const { return Vector4(XMVector3Transform(vec, m_mat)); }
 		INLINE Vector4  XM_CALLCONV operator* (const Vector4& vec) const { return Vector4(XMVector4Transform(vec, m_mat)); }
-		INLINE Matrix4  XM_CALLCONV operator* (const Matrix4& mat) const { return Matrix4(XMMatrixMultiply(mat, m_mat)); }
+		INLINE Matrix4  XM_CALLCONV operator* (const Matrix4& mat) const { return Matrix4(XMMatrixMultiply(m_mat, mat)); }
 
 		static INLINE Matrix4 XM_CALLCONV  MakeScale(float scale) { return Matrix4(XMMatrixScaling(scale, scale, scale)); }
 		static INLINE Matrix4 XM_CALLCONV  MakeScale(const Vector3& scale) { return Matrix4(XMMatrixScalingFromVector(scale)); }


### PR DESCRIPTION
When I try using matrix4 to compute my MVP constant data， I found unexcept result. So I read [MSDN doc](https://learn.microsoft.com/zh-cn/windows/win32/api/directxmath/nf-directxmath-xmmatrixmultiply), then  found the order 
 of param is wrong. 